### PR TITLE
chore: trigger workflow for branches other than main, trigger for PR on main

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,0 +1,35 @@
+name: Lint Code Base
+
+# Run the workflow everytime a pull request is made
+on:
+  push:
+    # Trigger workflow only for branches other than main, ignore for main
+    branches-ignore:
+      - main
+  pull_request:
+    # Trigger workflow for any pull request on the branch main
+    branches:
+      - main
+
+jobs:
+  # specify the job key -> will be used as the job name
+  # if a job name isn't provided
+  super-lint:
+    # job name
+    name: Python Linter
+    # type of machine to run on
+    runs-on: ubuntu-latest
+
+    steps:
+      # checks out a copy of the repo onto the machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      # runs super-linter action
+      - name: Run Super-Linter
+        uses: github/super-linter@v3
+        env:
+          DEFAULT_BRANCH: main
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_ISORT: false
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -6,10 +6,6 @@ on:
     # Trigger workflow only for branches other than main, ignore for main
     branches-ignore:
       - main
-  pull_request:
-    # Trigger workflow for any pull request on the branch main
-    branches:
-      - main
 
 jobs:
   # specify the job key -> will be used as the job name


### PR DESCRIPTION
The current linter workflow action is triggered only on a pull request for the main branch instead of every push on branches other than main.

Therefore, we add conditional triggers for `push` and `pull_request` in the linter.